### PR TITLE
Improvements for deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ typings/
 .idea/
 
 dist
+
+src/config.ts
+app-bundle.zip

--- a/package.json
+++ b/package.json
@@ -2,15 +2,17 @@
   "name": "telegram-songsearchbot",
   "version": "1.0.0",
   "description": "Searches for music in popular streaming platforms (and youtube) to allow better UX of music sharing in telegram chats",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "start": "npm run lint && npm-run-all -p -r ts-watch lint-watch",
+    "start": "node dist/index.js",
+    "dev": "npm run lint && npm-run-all -p -r ts-watch lint-watch",
     "lint": "tslint -p ./ --force --format stylish",
     "ts-watch": "tsc --watch --pretty",
     "lint-watch": "onchange './src/**/*.ts' -d 300 -- npm run lint",
     "build": "tsc",
     "test": "jest",
-    "test-watch": "jest --watchAll"
+    "test-watch": "jest --watchAll",
+    "pack": "npm run build && zip app-`date -u +\"%Y%m%d%H%M\"`.zip package.json dist/*"
   },
   "dependencies": {
     "@types/bluebird": "^3.5.20",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,12 @@ import {SearchAMusic} from "./apple-music";
 import {config} from "./config";
 import {SearchSpotify} from "./spotify";
 
-const token = config.telegramToken;
+const packageConfig = require("../package.json");
 
+const startDate = new Date();
+console.warn(`Start server v${packageConfig.version} (${startDate})`);
+
+const token = config.telegramToken;
 const bot = new Telegraf(token);
 const commandRegexp = /\/songlink /;
 


### PR DESCRIPTION
- `start` command renamed to `dev`. Use `npm run dev` for developing, we need npm start to run app on production server
- added simple logging for server startup
- added `npm run pack`. You can create valid zip archives for Amazon EBS deployments